### PR TITLE
Allow meme customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@ it generates a memelike images as context my website https://www.wt4q.com as its
 ## Features
 
 - Supports multiple aspect ratios including 1:1, 3:2, 2:3, 4:3, 3:4, 16:9, and 9:16.
+- Upload images or videos as meme backgrounds.
+- Aspect ratio can be adjusted even after media upload.
+- Select different fonts and tweak font size for the meme text.

--- a/mememaker/src/app/globals.css
+++ b/mememaker/src/app/globals.css
@@ -63,6 +63,11 @@
   margin-left: 4px;
 }
 
+.mememaker-slider {
+  margin-left: 4px;
+  accent-color: #6bc6ff;
+}
+
 .mememaker-lock {
   font-size: 12px;
   color: #6bc6ff;


### PR DESCRIPTION
## Summary
- Allow changing aspect ratio even after media upload and auto-detect the closest aspect for new media
- Add font family selector and font size slider for meme text
- Document video background support and new customization options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(could not run: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689491a468888327ac6aad3a9b28593c