### PR TITLE
Fix hydration mismatch in meme editor

### DIFF
--- a/mememaker/src/app/page.tsx
+++ b/mememaker/src/app/page.tsx
@@ -50,9 +50,8 @@ export default function Home(): JSX.Element {
   const [mediaPlacement, setMediaPlacement] = useState<'center' | 'above' | 'below'>('center');
   const [fontFamily, setFontFamily] = useState<string>('Impact, Arial, sans-serif');
   const [customFontSize, setCustomFontSize] = useState<number | null>(null);
-  const [windowWidth, setWindowWidth] = useState<number>(
-    typeof window !== 'undefined' ? window.innerWidth : 0
-  );
+  // Start with a fixed value so server and client markup match during hydration
+  const [windowWidth, setWindowWidth] = useState<number>(0);
   const previewRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid hydration mismatch by initializing window width state to 0

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68949e1270a883278836f7eebe2f6978