### PR TITLE
Handle video metadata during upload

### DIFF
--- a/mememaker/src/app/page.tsx
+++ b/mememaker/src/app/page.tsx
@@ -111,6 +111,7 @@ export default function Home(): JSX.Element {
         img.src = url;
       } else if (file.type.startsWith('video')) {
         const video = document.createElement('video');
+        video.preload = 'metadata';
         video.onloadedmetadata = () => {
           const ratio = video.videoWidth / video.videoHeight;
           setMedia({
@@ -123,6 +124,7 @@ export default function Home(): JSX.Element {
           setAspect(findClosestAspect(ratio));
         };
         video.src = url;
+        video.load();
       }
     }
   });


### PR DESCRIPTION
## Summary
- preload video metadata and explicitly load video files so dimensions are available before setting meme state

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_6894bc0c8e4c8327b36be519b66abb03