### PR TITLE
Handle video frame loading before preview

### DIFF
--- a/mememaker/src/app/page.tsx
+++ b/mememaker/src/app/page.tsx
@@ -112,7 +112,12 @@ export default function Home(): JSX.Element {
       } else if (file.type.startsWith('video')) {
         const video = document.createElement('video');
         video.preload = 'metadata';
+        video.muted = true;
         video.onloadedmetadata = () => {
+          // Load the first frame so dimensions are available
+          video.currentTime = 0;
+        };
+        video.onloadeddata = () => {
           const ratio = video.videoWidth / video.videoHeight;
           setMedia({
             url,


### PR DESCRIPTION
## Summary
- Ensure video is muted and forces first frame to load so dimensions are available
- Populate media state only after video data is ready

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6894bee9d76083278b5dacf77781a9be