### PR TITLE
feat: enable video meme export

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ it generates a memelike images as context my website https://www.wt4q.com as its
 - Upload images or videos as meme backgrounds.
 - Aspect ratio can be adjusted even after media upload.
 - Select different fonts and tweak font size for the meme text.
+- Download your meme as an image or a video.

--- a/mememaker/README.md
+++ b/mememaker/README.md
@@ -4,6 +4,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 - Create memes from images or videos.
 - Customize aspect ratio, text, fonts, and watermarks.
+- Export memes as PNG images or WebM videos.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add MediaRecorder-based video export for memes
- expose Download Video button when uploading videos
- document image and video export options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea0e16208327bb6354e197ac5a5b