### PR TITLE
Fix video download loop issue

### DIFF
--- a/mememaker/src/app/page.tsx
+++ b/mememaker/src/app/page.tsx
@@ -198,15 +198,23 @@ export default function Home(): JSX.Element {
     };
 
     videoEl.currentTime = 0;
+    const prevLoop = videoEl.loop;
+    videoEl.loop = false;
+
+    const handleEnded = (): void => {
+      recorder.stop();
+    };
+    videoEl.addEventListener('ended', handleEnded);
+
     await videoEl.play();
     drawFrame();
 
     await new Promise(resolve => {
-      videoEl.onended = () => {
-        recorder.stop();
-      };
       recorder.onstop = () => resolve(null);
     });
+
+    videoEl.removeEventListener('ended', handleEnded);
+    videoEl.loop = prevLoop;
 
     const blob = new Blob(chunks, { type: 'video/webm' });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- ensure MediaRecorder stops by disabling loop and awaiting `ended` event when downloading video

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_689508d21dd883278c7b35320d8c6ef5