### PR TITLE
Add padding and margin to media

### DIFF
--- a/mememaker/src/app/page.tsx
+++ b/mememaker/src/app/page.tsx
@@ -358,7 +358,10 @@ function MediaComponent({ media }: { media: MediaType }): JSX.Element {
             objectFit: 'contain',
             display: 'block',
             borderRadius: 20,
-            background: '#222'
+            background: '#222',
+            padding: 20,
+            margin: 20,
+            boxSizing: 'border-box'
           }}
         />
       ) : (
@@ -376,7 +379,10 @@ function MediaComponent({ media }: { media: MediaType }): JSX.Element {
             objectFit: 'contain',
             display: 'block',
             borderRadius: 20,
-            background: '#222'
+            background: '#222',
+            padding: 20,
+            margin: 20,
+            boxSizing: 'border-box'
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- prevent text overflow by adding padding and margin to images and videos

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689508c02db08327a1af1a050a76ed14